### PR TITLE
fix: add AWS credentials config for Spark S3 access

### DIFF
--- a/CloudFormation/cloudFormation.yml
+++ b/CloudFormation/cloudFormation.yml
@@ -265,6 +265,13 @@ Resources:
               - dynamodb:UpdateItem
               - dynamodb:Query
             Resource: !GetAtt ChatHistoryTable.Arn
+          - Effect: Allow
+            Action:
+              - bedrock:InvokeModel
+              - bedrock:InvokeModelWithResponseStream
+              - bedrock:ListFoundationModels
+              - bedrock:GetFoundationModel
+            Resource: '*'
       Roles:
         - !Ref SparkOnLambdaRole
  
@@ -335,6 +342,13 @@ Resources:
                 Action:
                   - lambda:InvokeFunction
                 Resource: !GetAtt SparkOnLambda.Arn
+              - Effect: Allow
+                Action:
+                  - bedrock:InvokeModel
+                  - bedrock:InvokeModelWithResponseStream
+                  - bedrock:ListFoundationModels
+                  - bedrock:GetFoundationModel
+                Resource: '*'
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -394,8 +408,8 @@ Resources:
           sed -i -e "s/{{REGION}}/${AWS::Region}/g" config.json
 
 
-          # Start the Bluebear Streamlit app in a tmux session
-          tmux new -d -s mysession "python3 -m streamlit run bedrock-chat.py"
+          # Start the Bluebear Streamlit app in a tmux session with logging
+          tmux new -d -s mysession "python3 -m streamlit run bedrock-chat.py 2>&1 | tee /root/bluebear/streamlit.log"
 
           echo "Setup complete. Use 'tmux attach -t mysession' to view the session."
 

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -13,12 +13,6 @@ ARG ICEBERG_FRAMEWORK_VERSION=3.3_2.12
 ARG ICEBERG_FRAMEWORK_SUB_VERSION=1.0.0
 ARG DEEQU_FRAMEWORK_VERSION=2.0.3-spark-3.3
 
-# AWS credentials with default values
-ARG AWS_ACCESS_KEY_ID=""
-ARG AWS_SECRET_ACCESS_KEY=""
-ARG AWS_SESSION_TOKEN=""
-ARG AWS_REGION="us-east-1"
-
 # Perform system updates and install dependencies
 RUN yum update -y && \
     yum -y update zlib && \
@@ -73,12 +67,6 @@ ENV PATH=${PATH}:${JAVA_HOME}/bin
 ENV INPUT_PATH=""
 ENV OUTPUT_PATH=""
 ENV CUSTOM_SQL=""
-
-# Replace the existing ENV statements for AWS credentials with these
-ENV AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-ENV AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-ENV AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
-ENV AWS_REGION=${AWS_REGION}
 
 # spark-class file is setting the memory to 1 GB
 COPY spark-class $SPARK_HOME/bin/

--- a/function_calling_utils.py
+++ b/function_calling_utils.py
@@ -1119,9 +1119,9 @@ spark.sparkContext.setLogLevel("WARN")
 # Configure Spark to use S3A FileSystem
 spark._jsc.hadoopConfiguration().set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
 
-# Configure Spark with AWS environmental credentials
+# Configure Spark with AWS credentials (uses Lambda's IAM role)
 spark._jsc.hadoopConfiguration().set("fs.s3a.aws.credentials.provider", 
-                                     "com.amazonaws.auth.EnvironmentVariableCredentialsProvider,")
+                                     "com.amazonaws.auth.DefaultAWSCredentialsProviderChain")
 
 # Read CSV data
 df = spark.read.csv("s3a://path/to/file/file.csv")
@@ -1236,7 +1236,12 @@ with open('/tmp/output.json', 'w') as f:
                                         "spark.driver.memory": "5G",
                                         "spark.dynamicAllocation.enabled": "false",
                                         "spark.shuffle.service.enabled": "false",                 
-                                        "spark.driver.bindAddress": "127.0.0.1",}
+                                        "spark.driver.bindAddress": "127.0.0.1",
+                                        "spark.hadoop.fs.s3a.impl": "org.apache.hadoop.fs.s3a.S3AFileSystem",
+                                        "spark.hadoop.fs.s3a.aws.credentials.provider": "com.amazonaws.auth.DefaultAWSCredentialsProviderChain",
+                                        "spark.hadoop.fs.s3a.endpoint": "s3.amazonaws.com",
+                                        "spark.hadoop.fs.s3a.path.style.access": "false",
+                                        "spark.hadoop.fs.s3a.connection.ssl.enabled": "true"}
                             
                             payload = {
                                 "body": {


### PR DESCRIPTION
- Add DefaultAWSCredentialsProviderChain to Spark configs
- Update Lambda spark_configs with S3A filesystem settings
- Fix credential provider chain for Lambda execution role

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
